### PR TITLE
🔧 Add doc8 config file

### DIFF
--- a/doc8.ini
+++ b/doc8.ini
@@ -1,0 +1,2 @@
+[doc8]
+file-encoding=utf8


### PR DESCRIPTION
Needed to specify the default file encoding to use to avoid exceptions
when trying to lint files that contain unicode.