### PR TITLE
📝 Add test coverage guide and update pull request doc

### DIFF
--- a/docs/development/repositories.rst
+++ b/docs/development/repositories.rst
@@ -170,3 +170,10 @@ health of the deployment can be enabled. Netlifiy can also be configured to
 post review comments with links to the deployed branches.
 
 
+Codecov
+-------
+
+Code coverage tools incentivize developers to write tests and increase
+coverage.  Codecov can provide code coverage (difference) at commits, pull
+requests or branches level. Codecov can be integrated into CircleCI testing,
+and the reports are automatically attached to each pull request as bot comment.

--- a/docs/guides/javascript.rst
+++ b/docs/guides/javascript.rst
@@ -50,6 +50,10 @@ Any unit testing framworks such as
 `mocha <https://www.npmjs.com/package/mocha>`_ or the equivalent should run
 tests stored in an appropriate directory.
 
+
+Test coverage can be integrated into each GitHub repos with `Codecov.io <https://docs.codecov.io/docs/node>`_
+by installing `codecov <https://github.com/codecov/example-node>`_.
+
 Prettier
 --------
 

--- a/docs/guides/pull_requests.rst
+++ b/docs/guides/pull_requests.rst
@@ -50,6 +50,12 @@ information on this feature.
    Sidebar of a Pull Request in GitHub displaying completed Reviewers,
    Assignees, and Labels fields
 
+GitHub pull-request templates can auto-populate the description field and
+provide a skeleton framework for developers to fill out. Templates help provide
+a baseline standard of informational quality and organizational rigor.
+
+`About pull request templates <https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository>`_
+
 Reviewers
 ---------
 
@@ -57,6 +63,13 @@ Reviewers should be requested for feedback on a pull request. According to the
 :ref:`development/repositories:The Anatomy of a Repository`, there should be a
 status check in place for all repositories that requires at least one reviewer
 to give an approval to the pull request.
+
+Reviews are required from at least one other developer for pull requests
+against `master`. If a feature introduced by a pull request potentially impacts
+other applications or developers, those stakeholders should also be requested
+for review and provide their consent via an approval.
+
+`About pull request reviews <https://help.github.com/articles/about-pull-request-reviews/>`_
 
 Assignees
 ---------
@@ -70,10 +83,5 @@ Labels
 Labels are useful for categorizing a pull request or issues. It is helpful for
 distilling open pull requests or summarizing changes in releases.
 
-
-Reviews are required from at least one other developer for pull requests
-against `master`. If a feature introduced by a pull request potentially impacts
-other applications or developers, those stakeholders should also be requested
-for review and provide their consent via an approval.
-
-`About pull request reviews <https://help.github.com/articles/about-pull-request-reviews/>`_
+Suggested labels are ``bug``, ``devops``, ``documentation``,
+``epic``, ``feature``, ``help wanted``, and ``refactor``.

--- a/docs/guides/python.rst
+++ b/docs/guides/python.rst
@@ -34,6 +34,9 @@ Testing
 -------
 
 Kids First uses `pytest <https://docs.pytest.org/en/latest/>`_ exclusively for
-running tests.
+running tests. Test should be stored in the `tests` directory at the top level
+of the project.
 
-Test should be stored in the `tests` directory at the top level of the project.
+Test coverage can be integrated into each GitHub repos with `Codecov.io <https://docs.codecov.io/docs/python>`_
+by installing `pytest-cov <https://pypi.org/project/pytest-cov/>`_  and
+`codecov <https://github.com/codecov/example-python/>`_ for Python projects.


### PR DESCRIPTION
1. Add Codecov integration guide for Python and JavaScript projects, to automatically get the code coverage report for each pull request.
    > This method is used in data-tracker and study-creator

2. Add pull request template guides and label suggestions.